### PR TITLE
Add a test to check for deadlock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ futures-timer = "3.0.2"
 gloo-timers = "0.2.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { version = "0.3.1", features = ["rt"] }
+tokio = { version = "1.14.0", features = ["full"] }
 async-std = "1.6.5"
 smol = "1.2.4"
 criterion = "0.3.3"

--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -1,0 +1,31 @@
+#[cfg(not(target_arch = "wasm32"))]
+mod concurrent {
+    use std::time::Duration;
+
+    use async_once::AsyncOnce;
+    use lazy_static::lazy_static;
+    use tokio::runtime::Runtime;
+
+    lazy_static! {
+        static ref FOO: AsyncOnce<u32> = AsyncOnce::new(async {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            1
+        });
+    }
+
+    /// this test triggers a deadlock the test never commpletes
+    #[test]
+    fn simultaneous_access() {
+        let child = std::thread::spawn(|| {
+            Runtime::new()
+                .unwrap()
+                .block_on(async { assert_eq!(FOO.get().await, &1) });
+        });
+
+        Runtime::new()
+            .unwrap()
+            .block_on(async { assert_eq!(FOO.get().await, &1) });
+
+        child.join().unwrap();
+    }
+}


### PR DESCRIPTION
The test should complete but it does not.

same issue as https://github.com/hjiayz/async_once/issues/1#issuecomment-990463605

Might be worth looking into whether this happens when both futures are in the same runtime.
